### PR TITLE
Add gear page with equipment and tools list

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,6 +49,7 @@
     <a href="/">Home</a>
     <a href="/resume/">Résumé</a>
     <a href="/posts/">Posts</a>
+    <a href="/gear/">Gear</a>
   </nav>
 
   <main>

--- a/gear.md
+++ b/gear.md
@@ -19,10 +19,13 @@ A running list of the tools and equipment I rely on. Links point to the manufact
 ## Audio / Video
 
 - **[Opal C1](https://opalcamera.com/opal-c1)** — A dedicated webcam that punches well above its weight. Makes a noticeable difference on calls and recordings.
+- **[Blue Yeti](https://www.bluemic.com/products/yeti/)** — A reliable USB microphone that delivers clear audio out of the box. No audio interface required.
 - **[Sennheiser Momentum 4 Wireless](https://us.sennheiser-hearing.com/products/momentum-4-wireless)** — Comfortable for long sessions, great noise cancellation, and the battery life is exceptional.
 
 ## Desk Setup
 
+- **[MacBook Pro 13-inch, M1 (2020)](https://support.apple.com/en-us/111893)** — The machine everything runs on. The M1 chip still holds up remarkably well.
 - **[Jarvis Bamboo Standing Desk](https://store.hermanmiller.com/standing-desks/jarvis-bamboo-standing-desk/2542428.html?lang=en_US)** — Solid, height-adjustable standing desk. The bamboo top is a nice touch.
+- **[Herman Miller Aeron](https://www.hermanmiller.com/products/seating/office-chairs/aeron-chairs/)** — The chair I wish I'd bought sooner. Worth every penny for long work sessions.
 - **[OWC 11-Port Thunderbolt Dock](https://www.owc.com/solutions/thunderbolt-dock)** — Keeps everything connected with one cable to the laptop. Reliable and well-built.
 - **[Lenovo ThinkVision P44w](https://support.lenovo.com/us/en/solutions/pd500278-thinkvision-p44w-10-monitor-overview-and-service-parts)** — A wide-format ultrawide monitor that gives plenty of screen real estate without the complexity of a dual-monitor setup.

--- a/gear.md
+++ b/gear.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Gear
+permalink: /gear/
+---
+
+# Gear
+
+A running list of the tools and equipment I rely on. Links point to the manufacturer's page by default.
+
+*Some links may be affiliate links. If you purchase through one, I may earn a small commission at no extra cost to you — I only list gear I actually use.*
+
+---
+
+## Software
+
+- **[Screen Studio](https://screen.studio/)** — My go-to for recording clean, polished screen recordings. The auto-zoom and editing features make it genuinely fun to use.
+
+## Audio / Video
+
+- **[Opal C1](https://opalcamera.com/opal-c1)** — A dedicated webcam that punches well above its weight. Makes a noticeable difference on calls and recordings.
+- **[Sennheiser Momentum 4 Wireless](https://us.sennheiser-hearing.com/products/momentum-4-wireless)** — Comfortable for long sessions, great noise cancellation, and the battery life is exceptional.
+
+## Desk Setup
+
+- **[Jarvis Bamboo Standing Desk](https://store.hermanmiller.com/standing-desks/jarvis-bamboo-standing-desk/2542428.html?lang=en_US)** — Solid, height-adjustable standing desk. The bamboo top is a nice touch.
+- **[OWC 11-Port Thunderbolt Dock](https://www.owc.com/solutions/thunderbolt-dock)** — Keeps everything connected with one cable to the laptop. Reliable and well-built.
+- **[Lenovo ThinkVision P44w](https://support.lenovo.com/us/en/solutions/pd500278-thinkvision-p44w-10-monitor-overview-and-service-parts)** — A wide-format ultrawide monitor that gives plenty of screen real estate without the complexity of a dual-monitor setup.


### PR DESCRIPTION
## Summary
Added a new "Gear" page to the site that documents the tools and equipment currently in use, along with a navigation link to access it.

## Changes
- **New page**: Created `gear.md` with a curated list of software, audio/video, and desk setup equipment
  - Organized into three categories: Software, Audio/Video, and Desk Setup
  - Includes brief descriptions of why each item is valued
  - Links point to manufacturer pages with optional affiliate link disclosure
- **Navigation**: Updated `_layouts/default.html` to add a "Gear" link in the main navigation menu

## Implementation Details
- The gear page follows the existing Jekyll layout conventions with YAML front matter
- Includes a transparent note about potential affiliate links
- Equipment list covers productivity software (Screen Studio), recording/communication gear (Opal C1, Blue Yeti, Sennheiser headphones), and desk essentials (MacBook Pro, standing desk, chair, dock, monitor)

https://claude.ai/code/session_01KswpWj8Fdgwc7fySXzYfkJ