### PR TITLE
feat: add post "Write, execute, read"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,11 @@ All CSS is inline in `_layouts/default.html` (lines 10-45). Uses system fonts an
 
 GitHub Pages automatically builds and deploys from the `main` branch. No manual build or deployment steps required.
 
+## Git Conventions
+
+- **Never** include `Co-Authored-By: Claude` lines in commit messages
+- **Never** include `🤖 Generated with Claude Code` (or any Claude/AI attribution) in PR descriptions or commit messages
+
 ## AEO (Agent Engine Optimization)
 
 `llms.txt` and `llms-full.txt` serve structured content to AI agents (ChatGPT, Claude, Perplexity, etc.).

--- a/_posts/2026-05-04-write-execute-read.md
+++ b/_posts/2026-05-04-write-execute-read.md
@@ -1,0 +1,37 @@
+---
+title: "Write, execute, read"
+date: 2026-05-04
+description: "A mental shift: write and execute immediately after reading, then let the output become a portable, reusable artifact for future work."
+tags: []
+---
+
+Write and execute immediately after reading anything. Let the output stand as a portable, reusable artifact for future work.
+
+I recently started re-reading [The Creative Act: A Way of Being](https://sites.prh.com/thecreativeact) by Rick Rubin. My creative prompt right now is to write and execute more rather than read, so I'm responding to chapters in relation to the season of life I'm in. My anchor line from Chapter 1, "Everyone is a creator":
+
+> *"Attuned choice by attuned choice, your entire life is a form of self-expression." (3)*
+
+If I had to express where I've been and where I want to go:
+
+```diff
+- [[:read, 80], [:write, 15], [:execute, 5]]
++ [[:write, 40], [:execute, 40], [:read, 20]]
+```
+
+The catalyst was [HEAR EVERYTHING with Knxwledge](https://www.youtube.com/watch?v=ILf1XYkWxbY). From the Instagram description:
+
+> The film traces his journey from Los Angeles to Tokyo, where he embarks on a deeply personal musical and cultural exploration of the city he now calls home.
+
+> For the first time on film, Knxwledge opens up about his path from a church-going kid, for whom video game music was among the only sounds he could hear besides gospel. To winning Grammys and eventually creating music for the very games that first inspired him.
+
+> Part documentary, part love letter to Japan, the film follows Knxwledge as he immerses himself in a new environment, drawing constant inspiration from the people he meets and making beats at every possible moment. Always in headphones as he road-tests the ATH-R50x throughout his journey.
+
+It was one of those videos that made me stop mid-work and replay certain scenes and songs repeatedly until the material fully permeated.
+
+His creative process is what I kept coming back to. The moment Knxwledge experienced something, he made a beat, a soundscape as a method of capture. Reading became writing; composing sounds together became the execute step, published to Bandcamp or wherever. That loop got me thinking about my own work.
+
+I spent part of my childhood in Japan, and some of my earlier years at GitHub were there too. The scenes in the film spoke directly to how that culture, those people, and that ambience shaped my creativity and sense of self. This post marks that moment. A commitment to write and execute more, and break the habit of consuming without doing anything with it.
+
+```shell
+chmod 700 ./francisfuzz
+```


### PR DESCRIPTION
## Summary

- New blog post: "Write, execute, read" (2026-05-04)
- Explores a mental shift from passive reading to writing and executing immediately after consuming content
- References Rick Rubin's *The Creative Act* and the Knxwledge documentary as catalysts
- Audited and cleaned with the [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) skill

## AEO / LLM visibility

No manual changes needed to `llms.txt` or `llms-full.txt`. Both files use Jekyll Liquid loops (established in #45) that automatically include every post at build time:

- **`llms.txt`** — emits `[title](url): description` for each post
- **`llms-full.txt`** — emits title, URL, date, description, and full stripped content for each post

On merge, GitHub Pages rebuilds and the post is live in both files for AI crawlers (ClaudeBot, GPTBot, PerplexityBot, etc.).